### PR TITLE
Support nested inline styles and escaping them with '\'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tmp
 out
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tmp
 out
 node_modules
+*.swp

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ A convenience function, applying the provided styles to the input string and the
 Inline styling can be applied using the syntax `[style-list]{text to format}`, where `style-list` is a space-separated list of styles from [ansi.style](#module_ansi-escape-sequences.style). For example `[bold white bg-red]{bold white text on a red background}`.
 
 Use a single backslash to prevent parsing of a sequence, or a double backslash
-to get a single '\' character.
+to get a single '\\' character.
 
 **Kind**: static method of [<code>ansi-escape-sequences</code>](#module_ansi-escape-sequences)  
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ Various formatting styles (aka Select Graphic Rendition codes).
 | magenta | <code>string</code> | <code>&quot;\u001b[35m&quot;</code> | 
 | cyan | <code>string</code> | <code>&quot;\u001b[36m&quot;</code> | 
 | white | <code>string</code> | <code>&quot;\u001b[37m&quot;</code> | 
-| gray | <code>string</code> | <code>&quot;\u001b[90m&quot;</code> |
+| grey | <code>string</code> | <code>&quot;\u001b[90m&quot;</code> | 
+| gray | <code>string</code> | <code>&quot;\u001b[90m&quot;</code> | 
 | &quot;bg-black&quot; | <code>string</code> | <code>&quot;\u001b[40m&quot;</code> | 
 | &quot;bg-red&quot; | <code>string</code> | <code>&quot;\u001b[41m&quot;</code> | 
 | &quot;bg-green&quot; | <code>string</code> | <code>&quot;\u001b[42m&quot;</code> | 
@@ -224,7 +225,8 @@ Various formatting styles (aka Select Graphic Rendition codes).
 | &quot;bg-magenta&quot; | <code>string</code> | <code>&quot;\u001b[45m&quot;</code> | 
 | &quot;bg-cyan&quot; | <code>string</code> | <code>&quot;\u001b[46m&quot;</code> | 
 | &quot;bg-white&quot; | <code>string</code> | <code>&quot;\u001b[47m&quot;</code> | 
-| &quot;bg-gray&quot; | <code>string</code> | <code>&quot;\u001b[100m&quot;</code> |
+| &quot;bg-grey&quot; | <code>string</code> | <code>&quot;\u001b[100m&quot;</code> | 
+| &quot;bg-gray&quot; | <code>string</code> | <code>&quot;\u001b[100m&quot;</code> | 
 
 **Example**  
 ```js
@@ -255,6 +257,9 @@ Returns an ansi sequence setting one or more effects
 A convenience function, applying the provided styles to the input string and then resetting.
 
 Inline styling can be applied using the syntax `[style-list]{text to format}`, where `style-list` is a space-separated list of styles from [ansi.style](#module_ansi-escape-sequences.style). For example `[bold white bg-red]{bold white text on a red background}`.
+
+Use a single backslash to prevent parsing of a sequence, or a double backslash
+to get a single '\' character.
 
 **Kind**: static method of [<code>ansi-escape-sequences</code>](#module_ansi-escape-sequences)  
 

--- a/lib/ansi-escape-sequences.js
+++ b/lib/ansi-escape-sequences.js
@@ -115,7 +115,7 @@ ansi.styles = function (effectArray) {
  * Inline styling can be applied using the syntax `[style-list]{text to format}`, where `style-list` is a space-separated list of styles from {@link module:ansi-escape-sequences.style ansi.style}. For example `[bold white bg-red]{bold white text on a red background}`.
  *
  * Use a single backslash to prevent parsing of a sequence, or a double backslash
- * to get a single '\' character.
+ * to get a single '\\' character.
  *
  * @param {string} - the string to format
  * @param [styleArray] {string[]} - a list of styles to add to the input string

--- a/lib/ansi-escape-sequences.js
+++ b/lib/ansi-escape-sequences.js
@@ -152,7 +152,7 @@ ansi.format = function (str, styleArray, reset) {
     str = str.slice(match.index + match[0].length)
 
     if (match[0].charAt(0) === '\\') {
-      if (match[0] !== '\\\\') {
+      if (match[0] !== '\\\\' && depth === 0) {
         tmp += match[0].slice(1)
         continue
       }

--- a/lib/ansi-escape-sequences.js
+++ b/lib/ansi-escape-sequences.js
@@ -131,7 +131,7 @@ ansi.styles = function (effectArray) {
  * '\u001b[32;1mwhat?\u001b[0m'
  */
 ansi.format = function (str, styleArray, reset) {
-  const re = /\\?(\[([\w\s-]+)\]{|}|\\\\)/
+  const re = /\\?(?:\[([\w\s-]+)\]{|})|\\\\/
   let depth = 0
   let tmp = ''
   let result = ''
@@ -151,17 +151,17 @@ ansi.format = function (str, styleArray, reset) {
     str = str.slice(match.index + match[0].length)
 
     if (match[0].charAt(0) === '\\') {
-      tmp += match[0].slice(1)
-      continue
-    }
-
-    if (match[1] === '}') {
+      if (match[0] !== '\\\\') {
+        tmp += match[0].slice(1)
+        continue
+      }
+    } else if (match[0] === '}') {
       depth--;
 
       if (depth < 0) {
         depth = 0
       } else if (depth === 0) {
-        result += ansi.format(tmp, inlineStyles, (reset || ansi.style.reset) + styles)
+        result += ansi.format(tmp, inlineStyles, ansi.style.reset + styles)
         tmp = ''
         continue
       }
@@ -169,19 +169,17 @@ ansi.format = function (str, styleArray, reset) {
       depth++;
 
       if (depth === 1) {
-        result += tmp;
+        result += tmp.replace(/\\\\/g, '\\')
         tmp = ''
-        inlineStyles = match[2].split(/\s+/)
+        inlineStyles = match[1].split(/\s+/)
         continue
       }
     }
 
-    tmp += match[1];
+    tmp += match[0];
   }
 
-  result += tmp + str
-
-  result = result.replace(/\\\\/g, '\\')
+  result += tmp.replace(/\\\\/g, '\\') + str
 
   if (styles) {
     result = styles + result

--- a/lib/ansi-escape-sequences.js
+++ b/lib/ansi-escape-sequences.js
@@ -161,7 +161,7 @@ ansi.format = function (str, styleArray, reset) {
       if (depth < 0) {
         depth = 0
       } else if (depth === 0) {
-        result += ansi.format(tmp, inlineStyles, ansi.style.reset + styles)
+        result += ansi.format(tmp, inlineStyles, (reset || ansi.style.reset) + styles)
         tmp = ''
         continue
       }

--- a/lib/ansi-escape-sequences.js
+++ b/lib/ansi-escape-sequences.js
@@ -114,6 +114,9 @@ ansi.styles = function (effectArray) {
  *
  * Inline styling can be applied using the syntax `[style-list]{text to format}`, where `style-list` is a space-separated list of styles from {@link module:ansi-escape-sequences.style ansi.style}. For example `[bold white bg-red]{bold white text on a red background}`.
  *
+ * Use a single backslash to prevent parsing of a sequence, or a double backslash
+ * to get a single '\' character.
+ *
  * @param {string} - the string to format
  * @param [styleArray] {string[]} - a list of styles to add to the input string
  * @returns {string}
@@ -127,20 +130,63 @@ ansi.styles = function (effectArray) {
  * > ansi.format('[green bold]{what?}')
  * '\u001b[32;1mwhat?\u001b[0m'
  */
-ansi.format = function (str, styleArray) {
-  const re = /\[([\w\s-]+)\]{([^]*?)}/
-  let matches
+ansi.format = function (str, styleArray, reset) {
+  const re = /(^|[^\\])(\[([\w\s-]+)\]{|})/
+  let depth = 0
+  let tmp = ''
+  let result = ''
+  let styles = ''
+  let inlineStyles
+  let match
+
   if (!str) return ''
 
-  while (matches = str.match(re)) {
-    const inlineStyles = matches[1].split(/\s+/)
-    const inlineString = matches[2]
-    str = str.replace(matches[0], ansi.format(inlineString, inlineStyles))
+  if (styleArray && styleArray.length) {
+    styles = ansi.styles(styleArray)
+    reset = reset || ansi.style.reset
   }
 
-  return (styleArray && styleArray.length)
-    ? ansi.styles(styleArray) + str + ansi.style.reset
-    : str
+  while (match = re.exec(str)) {
+    tmp += str.slice(0, match.index) + match[1];
+    str = str.slice(match.index + match[0].length)
+
+    if (match[2] === '}') {
+      depth--;
+
+      if (depth < 0) {
+        depth = 0
+      } else if (depth === 0) {
+        result += ansi.format(tmp, inlineStyles, (reset || ansi.style.reset) + styles)
+        tmp = ''
+        continue
+      }
+    } else {
+      depth++;
+
+      if (depth === 1) {
+        result += tmp;
+        tmp = ''
+        inlineStyles = match[3].split(/\s+/)
+        continue
+      }
+    }
+
+    tmp += match[2];
+  }
+
+  result += tmp + str
+
+  result = result.replace(/\\\\/g, '\\')
+
+  if (styles) {
+    result = styles + result
+  }
+
+  if (reset) {
+    result += reset
+  }
+
+  return result
 }
 
 /**

--- a/lib/ansi-escape-sequences.js
+++ b/lib/ansi-escape-sequences.js
@@ -131,7 +131,7 @@ ansi.styles = function (effectArray) {
  * '\u001b[32;1mwhat?\u001b[0m'
  */
 ansi.format = function (str, styleArray, reset) {
-  const re = /(^|[^\\])(\[([\w\s-]+)\]{|})/
+  const re = /\\?(\[([\w\s-]+)\]{|}|\\\\)/
   let depth = 0
   let tmp = ''
   let result = ''
@@ -147,10 +147,15 @@ ansi.format = function (str, styleArray, reset) {
   }
 
   while (match = re.exec(str)) {
-    tmp += str.slice(0, match.index) + match[1];
+    tmp += str.slice(0, match.index);
     str = str.slice(match.index + match[0].length)
 
-    if (match[2] === '}') {
+    if (match[0].charAt(0) === '\\') {
+      tmp += match[0].slice(1)
+      continue
+    }
+
+    if (match[1] === '}') {
       depth--;
 
       if (depth < 0) {
@@ -166,12 +171,12 @@ ansi.format = function (str, styleArray, reset) {
       if (depth === 1) {
         result += tmp;
         tmp = ''
-        inlineStyles = match[3].split(/\s+/)
+        inlineStyles = match[2].split(/\s+/)
         continue
       }
     }
 
-    tmp += match[2];
+    tmp += match[1];
   }
 
   result += tmp + str

--- a/lib/ansi-escape-sequences.js
+++ b/lib/ansi-escape-sequences.js
@@ -136,6 +136,7 @@ ansi.format = function (str, styleArray, reset) {
   let tmp = ''
   let result = ''
   let styles = ''
+  let currentBrackets = ''
   let inlineStyles
   let match
 
@@ -162,6 +163,7 @@ ansi.format = function (str, styleArray, reset) {
         depth = 0
       } else if (depth === 0) {
         result += ansi.format(tmp, inlineStyles, (reset || ansi.style.reset) + styles)
+        currentBrackets = ''
         tmp = ''
         continue
       }
@@ -171,6 +173,7 @@ ansi.format = function (str, styleArray, reset) {
       if (depth === 1) {
         result += tmp.replace(/\\\\/g, '\\')
         tmp = ''
+        currentBrackets = match[0]
         inlineStyles = match[1].split(/\s+/)
         continue
       }
@@ -179,7 +182,7 @@ ansi.format = function (str, styleArray, reset) {
     tmp += match[0]
   }
 
-  result += tmp.replace(/\\\\/g, '\\') + str
+  result += currentBrackets + tmp.replace(/\\\\/g, '\\') + str
 
   if (styles) {
     result = styles + result

--- a/lib/ansi-escape-sequences.js
+++ b/lib/ansi-escape-sequences.js
@@ -147,7 +147,7 @@ ansi.format = function (str, styleArray, reset) {
   }
 
   while (match = re.exec(str)) {
-    tmp += str.slice(0, match.index);
+    tmp += str.slice(0, match.index)
     str = str.slice(match.index + match[0].length)
 
     if (match[0].charAt(0) === '\\') {
@@ -156,7 +156,7 @@ ansi.format = function (str, styleArray, reset) {
         continue
       }
     } else if (match[0] === '}') {
-      depth--;
+      depth--
 
       if (depth < 0) {
         depth = 0
@@ -166,7 +166,7 @@ ansi.format = function (str, styleArray, reset) {
         continue
       }
     } else {
-      depth++;
+      depth++
 
       if (depth === 1) {
         result += tmp.replace(/\\\\/g, '\\')
@@ -176,7 +176,7 @@ ansi.format = function (str, styleArray, reset) {
       }
     }
 
-    tmp += match[0];
+    tmp += match[0]
   }
 
   result += tmp.replace(/\\\\/g, '\\') + str

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,25 +136,14 @@
       }
     },
     "command-line-args": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.6.tgz",
-      "integrity": "sha1-D/h6HdFZiQ3K6yoAWr2uceVQWfw=",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
+      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
+        "array-back": "2.0.0",
         "find-replace": "1.0.3",
         "typical": "2.6.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
-        }
       }
     },
     "command-line-tool": {
@@ -165,8 +154,8 @@
       "requires": {
         "ansi-escape-sequences": "3.0.0",
         "array-back": "1.0.4",
-        "command-line-args": "4.0.6",
-        "command-line-usage": "4.0.0",
+        "command-line-args": "4.0.7",
+        "command-line-usage": "4.0.1",
         "typical": "2.6.1"
       },
       "dependencies": {
@@ -182,24 +171,24 @@
       }
     },
     "command-line-usage": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.0.0.tgz",
-      "integrity": "sha1-gWsyeItY+f66RNHm2sYPyuspteo=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.0.1.tgz",
+      "integrity": "sha512-IqYzZuXizukrdhnbdUj2hh4iceycow+Jn10mER4lwU4IapYvl5ZzoRPsj5Yraew5oRk4yfFKMuULGvAfb5o29w==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "array-back": "1.0.4",
-        "table-layout": "0.4.0",
+        "ansi-escape-sequences": "4.0.0",
+        "array-back": "2.0.0",
+        "table-layout": "0.4.2",
         "typical": "2.6.1"
       },
       "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+        "ansi-escape-sequences": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
+          "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "array-back": "2.0.0"
           }
         }
       }
@@ -226,9 +215,9 @@
       }
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.0.tgz",
+      "integrity": "sha1-bvSgmwX5iw41jW2T1Mo8rsZnKAM=",
       "dev": true
     },
     "defer-promise": {
@@ -288,26 +277,6 @@
       "requires": {
         "acorn": "3.3.0",
         "acorn-jsx": "3.0.1"
-      }
-    },
-    "feature-detect-es6": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-      "integrity": "sha1-+IhzavnLDJH1VmO/pHYuuW7nBH8=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
-        }
       }
     },
     "file-set": {
@@ -701,7 +670,7 @@
         "array-back": "2.0.0",
         "defer-promise": "1.0.1",
         "lodash.pick": "4.4.0",
-        "stream-read-all": "0.1.1",
+        "stream-read-all": "0.1.2",
         "typical": "2.6.1"
       }
     },
@@ -774,13 +743,10 @@
       }
     },
     "stream-read-all": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-read-all/-/stream-read-all-0.1.1.tgz",
-      "integrity": "sha512-1bjIXLwe3idAFSWfIyGbChKt0G/pCJDsbKVMeuRseU/anV9VdF2Aq47LpKUzrWV5+60PJJ1Xljo8ea/9X7NFtw==",
-      "dev": true,
-      "requires": {
-        "test-runner": "0.4.0"
-      }
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-read-all/-/stream-read-all-0.1.2.tgz",
+      "integrity": "sha512-KX42xBg853m+KnwRtwCKT95ShopAbY/MNKs2dBQ0WkNeuJdqgQYRtGRbTlxdx0L6t979h3z/wMq2eMSAu7Tygw==",
+      "dev": true
     },
     "stream-via": {
       "version": "1.0.4",
@@ -795,27 +761,16 @@
       "dev": true
     },
     "table-layout": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.0.tgz",
-      "integrity": "sha1-xw/wRV2a3WO5H3wVp3kmKVwODn0=",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
+      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "deep-extend": "0.4.2",
+        "array-back": "2.0.0",
+        "deep-extend": "0.5.0",
         "lodash.padend": "4.6.1",
         "typical": "2.6.1",
-        "wordwrapjs": "2.0.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
-        }
+        "wordwrapjs": "3.0.0"
       }
     },
     "taffydb": {
@@ -831,26 +786,26 @@
       "dev": true
     },
     "test-runner": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/test-runner/-/test-runner-0.4.0.tgz",
-      "integrity": "sha512-9mYw9ccaZs6X+31KarOdblFsqclqQjHJnltE0IfuwLqtPg9Fx4kSQkpFCyiOf3+xpSocDfpRmO6fPvai0/HLRQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/test-runner/-/test-runner-0.4.1.tgz",
+      "integrity": "sha512-7Lk3XX7PsV3bZEBEciwxXzcUc4jzMIMomnxhrZ20uetlWUMFr4IJHAna1+82yzhOrdk5z2zFVlmISLp/oM1Gew==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "array-back": "1.0.4",
-        "command-line-args": "4.0.6",
-        "command-line-usage": "4.0.0",
+        "ansi-escape-sequences": "4.0.0",
+        "array-back": "2.0.0",
+        "command-line-args": "4.0.7",
+        "command-line-usage": "4.0.1",
         "file-set": "1.1.1",
         "reduce-flatten": "1.0.1"
       },
       "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+        "ansi-escape-sequences": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
+          "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "array-back": "2.0.0"
           }
         }
       }
@@ -961,26 +916,13 @@
       "dev": true
     },
     "wordwrapjs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
-      "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.3.1",
         "reduce-flatten": "1.0.1",
         "typical": "2.6.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
-        }
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "devDependencies": {
     "jsdoc-to-markdown": "^3.0.0",
-    "test-runner": "^0.4.0"
+    "test-runner": "^0.4.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -10,3 +10,12 @@ runner.test('format', function () {
 runner.test('inline format', function () {
   a.strictEqual(ansi.format('before [red underline]{clive} after'), 'before \u001b[31;4mclive\u001b[0m after')
 })
+
+runner.test('nested inline format', function () {
+  a.strictEqual(ansi.format('before [red underline]{inside [green]{nested}} after'),
+        'before \u001b[31;4minside \u001b[32mnested\u001b[0m\u001b[31;4m\u001b[0m after')
+})
+
+runner.test('escaped inline format', function () {
+  a.strictEqual(ansi.format('[red]{all this \\} is red} \\[green]{not green}'), '\u001b[31mall this \\} is red\u001b[0m \\[green]{not green}')
+})

--- a/test/test.js
+++ b/test/test.js
@@ -16,13 +16,13 @@ runner.test('nested inline format', function () {
         'before \u001b[31;4minside \u001b[32mnested\u001b[0m\u001b[31;4m\u001b[0m after')
 })
 
-runner.test('escaped inline format', function () {
-  a.strictEqual(ansi.format('[red]{all this \\} is red} \\[green]{not green}'), '\u001b[31mall this } is red\u001b[0m [green]{not green}')
-})
-
-runner.test('escaped inline format 2', function() {
+runner.test('nested inline format 2', function() {
   a.strictEqual(ansi.format('[red underline]{inside [green]{[bold]{nested} green}}'),
         '\u001b[31;4minside \u001b[32m\u001b[1mnested\u001b[0m\u001b[31;4m\u001b[32m green\u001b[0m\u001b[31;4m\u001b[0m');
+})
+
+runner.test('escaped inline format', function () {
+  a.strictEqual(ansi.format('[red]{all this \\} is red} \\[green]{not green}'), '\u001b[31mall this } is red\u001b[0m [green]{not green}')
 })
 
 runner.test('escaped escape sequence', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -21,5 +21,5 @@ runner.test('escaped inline format', function () {
 })
 
 runner.test('escaped escape sequence', function () {
-  a.strictEqual(ansi.format('\\[red]{not red} \\\\[red]{red\\\\}'), '')
+  a.strictEqual(ansi.format('\\[red]{not red} \\\\[red]{red\\\\}'), '[red]{not red} \\\u001b[31mred\\\u001b[0m')
 })

--- a/test/test.js
+++ b/test/test.js
@@ -16,9 +16,9 @@ runner.test('nested inline format', function () {
         'before \u001b[31;4minside \u001b[32mnested\u001b[0m\u001b[31;4m\u001b[0m after')
 })
 
-runner.test('nested inline format 2', function() {
+runner.test('nested inline format 2', function () {
   a.strictEqual(ansi.format('[red underline]{inside [green]{[bold]{nested} green}}'),
-        '\u001b[31;4minside \u001b[32m\u001b[1mnested\u001b[0m\u001b[31;4m\u001b[32m green\u001b[0m\u001b[31;4m\u001b[0m');
+        '\u001b[31;4minside \u001b[32m\u001b[1mnested\u001b[0m\u001b[31;4m\u001b[32m green\u001b[0m\u001b[31;4m\u001b[0m')
 })
 
 runner.test('escaped inline format', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -23,3 +23,7 @@ runner.test('escaped inline format', function () {
 runner.test('escaped escape sequence', function () {
   a.strictEqual(ansi.format('\\[red]{not red} \\\\[red]{red\\\\}'), '[red]{not red} \\\u001b[31mred\\\u001b[0m')
 })
+
+runner.test('nested escape sequences', function () {
+  a.strictEqual(ansi.format('[red]{\\\\\\\\}'), '\u001b[31m\\\\\u001b[0m')
+})

--- a/test/test.js
+++ b/test/test.js
@@ -4,39 +4,64 @@ const runner = new TestRunner()
 const a = require('assert')
 
 runner.test('format', function () {
-  a.strictEqual(ansi.format('clive', ['red', 'underline']), '\u001b[31;4mclive\u001b[0m')
+  a.strictEqual(
+    ansi.format('clive', ['red', 'underline']),
+    '\u001b[31;4mclive\u001b[0m'
+  )
 })
 
 runner.test('inline format', function () {
-  a.strictEqual(ansi.format('before [red underline]{clive} after'), 'before \u001b[31;4mclive\u001b[0m after')
+  a.strictEqual(
+    ansi.format('before [red underline]{clive} after'),
+    'before \u001b[31;4mclive\u001b[0m after'
+  )
 })
 
 runner.test('nested inline format', function () {
-  a.strictEqual(ansi.format('before [red underline]{inside [green]{nested}} after'),
-        'before \u001b[31;4minside \u001b[32mnested\u001b[0m\u001b[31;4m\u001b[0m after')
+  a.strictEqual(
+    ansi.format('before [red underline]{inside [green]{nested}} after'),
+    'before \u001b[31;4minside \u001b[32mnested\u001b[0m\u001b[31;4m\u001b[0m after'
+  )
 })
 
 runner.test('nested inline format 2', function () {
-  a.strictEqual(ansi.format('[red underline]{inside [green]{[bold]{nested} green}}'),
-        '\u001b[31;4minside \u001b[32m\u001b[1mnested\u001b[0m\u001b[31;4m\u001b[32m green\u001b[0m\u001b[31;4m\u001b[0m')
+  a.strictEqual(
+    ansi.format('[red underline]{inside [green]{[bold]{nested} green}}'),
+    '\u001b[31;4minside \u001b[32m\u001b[1mnested\u001b[0m\u001b[31;4m\u001b[32m green\u001b[0m\u001b[31;4m\u001b[0m'
+  )
 })
 
 runner.test('escaped inline format', function () {
-  a.strictEqual(ansi.format('[red]{all this \\} is red} \\[green]{not green}'), '\u001b[31mall this } is red\u001b[0m [green]{not green}')
+  a.strictEqual(
+    ansi.format('[red]{all this \\} is red} \\[green]{not green}'),
+    '\u001b[31mall this } is red\u001b[0m [green]{not green}'
+  )
 })
 
 runner.test('escaped escape sequence', function () {
-  a.strictEqual(ansi.format('\\[red]{not red} \\\\[red]{red\\\\}'), '[red]{not red} \\\u001b[31mred\\\u001b[0m')
+  a.strictEqual(
+    ansi.format('\\[red]{not red} \\\\[red]{red\\\\}'),
+    '[red]{not red} \\\u001b[31mred\\\u001b[0m'
+  )
 })
 
 runner.test('nested escape sequences', function () {
-  a.strictEqual(ansi.format('[red]{\\\\\\\\}'), '\u001b[31m\\\\\u001b[0m')
+  a.strictEqual(
+    ansi.format('[red]{\\\\\\\\}'),
+    '\u001b[31m\\\\\u001b[0m'
+  )
 })
 
 runner.test('unterminated format', function () {
-  a.strictEqual(ansi.format('[red]{uhoh'), 'uhoh')
+  a.strictEqual(
+    ansi.format('[red]{uhoh'),
+    'uhoh'
+  )
 })
 
 runner.test('dangling close', function () {
-  a.strictEqual(ansi.format('uhoh}'), 'uhoh}')
+  a.strictEqual(
+    ansi.format('uhoh}'),
+    'uhoh}'
+  )
 })

--- a/test/test.js
+++ b/test/test.js
@@ -27,3 +27,11 @@ runner.test('escaped escape sequence', function () {
 runner.test('nested escape sequences', function () {
   a.strictEqual(ansi.format('[red]{\\\\\\\\}'), '\u001b[31m\\\\\u001b[0m')
 })
+
+runner.test('unterminated format', function () {
+  a.strictEqual(ansi.format('[red]{uhoh'), 'uhoh')
+})
+
+runner.test('dangling close', function () {
+  a.strictEqual(ansi.format('uhoh}'), 'uhoh}')
+})

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,14 @@ runner.test('nested escape sequences', function () {
   )
 })
 
+runner.test('nested escape sequences 2', function () {
+  a.strictEqual(
+    ansi.format('[red]{[red]{\\[green]{asd\\}}}'),
+    '\u001b[31m\u001b[31m[green]{asd}\u001b[0m\u001b[31m\u001b[0m'
+  )
+})
+
+
 runner.test('unterminated format', function () {
   a.strictEqual(
     ansi.format('[red]{uhoh'),

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,11 @@ runner.test('escaped inline format', function () {
   a.strictEqual(ansi.format('[red]{all this \\} is red} \\[green]{not green}'), '\u001b[31mall this } is red\u001b[0m [green]{not green}')
 })
 
+runner.test('escaped inline format 2', function() {
+  a.strictEqual(ansi.format('[red underline]{inside [green]{[bold]{nested} green}}'),
+        '\u001b[31;4minside \u001b[32m\u001b[1mnested\u001b[0m\u001b[31;4m\u001b[32m green\u001b[0m\u001b[31;4m\u001b[0m');
+})
+
 runner.test('escaped escape sequence', function () {
   a.strictEqual(ansi.format('\\[red]{not red} \\\\[red]{red\\\\}'), '[red]{not red} \\\u001b[31mred\\\u001b[0m')
 })

--- a/test/test.js
+++ b/test/test.js
@@ -55,7 +55,7 @@ runner.test('nested escape sequences', function () {
 runner.test('unterminated format', function () {
   a.strictEqual(
     ansi.format('[red]{uhoh'),
-    'uhoh'
+    '[red]{uhoh'
   )
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -17,5 +17,9 @@ runner.test('nested inline format', function () {
 })
 
 runner.test('escaped inline format', function () {
-  a.strictEqual(ansi.format('[red]{all this \\} is red} \\[green]{not green}'), '\u001b[31mall this \\} is red\u001b[0m \\[green]{not green}')
+  a.strictEqual(ansi.format('[red]{all this \\} is red} \\[green]{not green}'), '\u001b[31mall this } is red\u001b[0m [green]{not green}')
+})
+
+runner.test('escaped escape sequence', function () {
+  a.strictEqual(ansi.format('\\[red]{not red} \\\\[red]{red\\\\}'), '')
 })


### PR DESCRIPTION
Adds support for nested inline styles like

`[bold red]{bold and red [green]{bold and green} bold and red again}`

as well as escaping control characters: 

`[red]{all this \} is red}`.